### PR TITLE
fix issue during mining

### DIFF
--- a/src/blockchain.ts
+++ b/src/blockchain.ts
@@ -82,7 +82,11 @@ const getAdjustedDifficulty = (latestBlock: Block, aBlockchain: Block[]) => {
     if (timeTaken < timeExpected / 2) {
         return prevAdjustmentBlock.difficulty + 1;
     } else if (timeTaken > timeExpected * 2) {
-        return prevAdjustmentBlock.difficulty - 1;
+        if (prevAdjustmentBlock.difficulty > 0) {
+            return prevAdjustmentBlock.difficulty - 1;
+        } else {
+            return 0;
+        }
     } else {
         return prevAdjustmentBlock.difficulty;
     }


### PR DESCRIPTION
The bug was caused when 
`timeTaken > timeExpected * 2`  at first round.
Originally, It would be -1, which is absolutely wrong.
So in order to avoid this bug, test if `prevAdjustmentBlock.difficulty > 0`.
if yes, then return prevAdjustmentBlock.difficulty - 1;
if not , then return prevAdjustmentBlock.difficulty;