### PR TITLE
updating return statement to ensure boolean return

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -140,7 +140,7 @@ const validateCoinbaseTx = (transaction: Transaction, blockIndex: number): boole
     }
     if (transaction.txIns.length !== 1) {
         console.log('one txIn must be specified in the coinbase transaction');
-        return;
+        return false;
     }
     if (transaction.txIns[0].txOutIndex !== blockIndex) {
         console.log('the txIn signature in coinbase tx must be the block height');


### PR DESCRIPTION
Minor issue... Apparently `false` is missing on the `return` statement of the second `if` in  `validateCoinbaseTx`, that has a `boolean` return type. It shouldn't affect the way it works though, since it tests for `!validateCoinbaseTx(...)` at [transaction.ts](https://github.com/lhartikk/naivecoin/blob/master/src/transaction.ts#L96).